### PR TITLE
V1.10.2 website change

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -2,6 +2,7 @@ plugin.video.rt
 ================
 Kodi Addon for Russia Today News
 
+Version 1.10.2 website change
 Version 1.10.1 website change
 Version 1.10.0 website change, added views
 version 1.9.4 added RT UK feed and cleaned up language strings

--- a/addon.xml
+++ b/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="plugin.video.rt"
        name="Russia Today News"
-       version="1.10.1"
+       version="1.10.2"
        provider-name="t1m">
   <requires>
     <import addon="xbmc.python" version="2.1.0"/>

--- a/changelog.txt
+++ b/changelog.txt
@@ -12,3 +12,4 @@ version 1.9.2 updated live stream urls, added auto speed
 version 1.9.4 added RT UK feed and cleaned up language strings
 Version 1.10.0 website change, added views
 Version 1.10.1 website change
+Version 1.10.2 website change

--- a/default.py
+++ b/default.py
@@ -74,19 +74,20 @@ def getShows():
 
 def getLive():
     ilist=[]
-    rlist = [("http://rt-a.akamaihd.net/ch_01@325605/%s.m3u8", __language__(30005)),
-             ("http://rt-a.akamaihd.net/ch_04@325608/%s.m3u8", __language__(30006)),
-             ("http://rt-a.akamaihd.net/ch_05@325609/%s.m3u8", __language__(30007)),
-             ("http://rt-a.akamaihd.net/ch_06@325610/%s.m3u8", __language__(30008)),
-             ("http://rt-a.akamaihd.net/ch_02@325606/%s.m3u8", __language__(30009)),
-             ("http://rt-a.akamaihd.net/ch_03@325607/%s.m3u8", __language__(30010))]
+    rlist = [("http://rt-eng-live.hls.adaptive.level3.net/rt/eng/%s.m3u8", __language__(30005)),
+             ("http://rt-usa-live.hls.adaptive.level3.net/rt/usa/%s.m3u8", __language__(30006)),
+             ("http://rt-doc-live.hls.adaptive.level3.net/rt/doc/%s.m3u8", __language__(30007)),
+             ("http://rt-uk-live.hls.adaptive.level3.net/rt/uk/%s.m3u8", __language__(30008)),
+             ("http://rt-esp-live.hls.adaptive.level3.net/rt/esp/%s.m3u8", __language__(30009)),
+             ("http://rt-ara-live.hls.adaptive.level3.net/rt/ara/%s.m3u8", __language__(30010))]
     res_names = ["Auto","720p","480p","320p","240p"]
+    res_paths = ["index","index2500","index1600","index800","index400"]
     i = int(addon.getSetting('rt_res'))
     res = res_names[i]
-    if res == "Auto": res = "master"
     res_str = res_names[i]
+    res_path = res_paths[i]
     for url, name in rlist:
-       url = url % res
+       url = url % res_path
        name = '%s%s' % (name, res_str)    
        liz=xbmcgui.ListItem(name, '',icon, None)
        liz.setProperty('fanart_image', addonfanart)


### PR DESCRIPTION
V1.10.1 does not work with live streams anymore. This patch contain updated URLs for the new video source of the live streams.